### PR TITLE
Check last 3 cards for Automa passing

### DIFF
--- a/src/services/CardDeck.ts
+++ b/src/services/CardDeck.ts
@@ -73,7 +73,7 @@ export default class CardDeck {
    */
   public isPass() : boolean {
     return (this._deck.length == 0)
-        || (this._deck.length <= 2 && (this.actionCard?.pass || false))
+        || (this._deck.length <= 3 && (this.actionCard?.pass || false))
   }
 
   /**

--- a/tests/unit/services/CardDeck.spec.ts
+++ b/tests/unit/services/CardDeck.spec.ts
@@ -84,20 +84,43 @@ describe('CardDeck', () => {
 
   it('draw-pass-last-3', () => {
     const cardDeck = CardDeck.fromPersistence({
-      deck: ['1','2','3','4'],
+      deck: ['6','7','1','2','3'],
       discard: [],
       reserve: []
     })
 
     expect(cardDeck.draw(), '1st draw').to.true
-    expect(cardDeck.actionCard?.id, '1st action card').to.eq('2')
-    expect(cardDeck.supportCard?.id, '1st support card').to.eq('1')
+    expect(cardDeck.actionCard?.id, '1st action card').to.eq('7')
+    expect(cardDeck.supportCard?.id, '1st support card').to.eq('6')
     expect(cardDeck.isPass(), '1st pass').to.false
 
     expect(cardDeck.draw(), '2nd draw').to.true
-    expect(cardDeck.actionCard?.id, '2nd action card').to.eq('3')
-    expect(cardDeck.supportCard?.id, '2nd support card').to.eq('2')
+    expect(cardDeck.actionCard?.id, '2nd action card').to.eq('1')
+    expect(cardDeck.supportCard?.id, '2nd support card').to.eq('7')
     expect(cardDeck.isPass(), '2nd pass').to.true
+  })
+
+  it('draw-pass-last-2', () => {
+    const cardDeck = CardDeck.fromPersistence({
+      deck: ['6','1','7','2','3'],
+      discard: [],
+      reserve: []
+    })
+
+    expect(cardDeck.draw(), '1st draw').to.true
+    expect(cardDeck.actionCard?.id, '1st action card').to.eq('1')
+    expect(cardDeck.supportCard?.id, '1st support card').to.eq('6')
+    expect(cardDeck.isPass(), '1st pass').to.false
+
+    expect(cardDeck.draw(), '2nd draw').to.true
+    expect(cardDeck.actionCard?.id, '2nd action card').to.eq('7')
+    expect(cardDeck.supportCard?.id, '2nd support card').to.eq('1')
+    expect(cardDeck.isPass(), '2nd pass').to.false
+
+    expect(cardDeck.draw(), '3nd draw').to.true
+    expect(cardDeck.actionCard?.id, '3rd action card').to.eq('2')
+    expect(cardDeck.supportCard?.id, '3rd support card').to.eq('7')
+    expect(cardDeck.isPass(), '3rd pass').to.true
   })
 
   it('prepareForNextRound', () => {


### PR DESCRIPTION
Only the last 2 cards where checked for Automa to pass in it's turn - that was wrongly taken over from the Terra Mystica solo helper app. In Gaia Project, the last 3 cards have to be checked for pass.